### PR TITLE
Added ability to define id

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-source-podcast-rss-feed",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@babel/preset-env": "^7.8.3",
     "babel-preset-gatsby-package": "^0.2.15",
     "cross-env": "^6.0.3",
-    "lodash": "^4.17.15",
+    "lodash": "^4.17.15"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "@babel/core": "^7.8.3",
     "@babel/preset-env": "^7.8.3",
     "babel-preset-gatsby-package": "^0.2.15",
-    "cross-env": "^6.0.3"
+    "cross-env": "^6.0.3",
+    "lodash": "^4.17.15",
   },
   "engines": {
     "node": ">=8.0.0"

--- a/src/default-options.js
+++ b/src/default-options.js
@@ -1,3 +1,3 @@
 export default {
-  id: link
+  id: 'link'
 }

--- a/src/default-options.js
+++ b/src/default-options.js
@@ -1,0 +1,3 @@
+export default {
+  id: link
+}

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -1,18 +1,20 @@
+import merge from "lodash/merge"
+import defaultOptions from "./default-options"
+
 const Parser = require("rss-parser")
 
 exports.sourceNodes = async (
   { actions, createNodeId, createContentDigest },
-  configOptions
+  pluginOptions
 ) => {
   const { createNode } = actions
+  const options = merge(defaultOptions, pluginOptions)
 
-  delete configOptions.plugins
-
-  const { feedURL } = configOptions
+  const { feedURL } = options
   const feed = await parseURL(feedURL)
 
   feed.items.forEach(item => {
-    const nodeId = item.link
+    const nodeId = item[options.id]
     const type = `podcastRssFeedEpisode`
     const description = `This node represents an individual podcast episode from the provided podcast rss feed.`
     createNode({
@@ -30,8 +32,8 @@ exports.sourceNodes = async (
   return
 }
 
-exports.onPreBootstrap = ({ reporter }, configOptions) => {
-  const { feedURL } = configOptions
+exports.onPreBootstrap = ({ reporter }, pluginOptions) => {
+  const { feedURL } = pluginOptions
 
   if (!feedURL) {
     reporter.panic(`Required plugin config option "feedURL" missng.`)


### PR DESCRIPTION
If a podcast uses the same link for every episode the plugin does not work as expected because there will be just one episode. I've added the ability to define the field for the id. Actually it would make sense to use guid as the id because it's already naturally an id.